### PR TITLE
chore: Add `rust-toolchain` file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Explicitly pin toolchain to version `1.86.0` (current stable).